### PR TITLE
Fix box_with_door door mesh creation

### DIFF
--- a/3d_model_maker/parametric_cad/examples/box_with_door.py
+++ b/3d_model_maker/parametric_cad/examples/box_with_door.py
@@ -24,18 +24,13 @@ def create_box_with_door(box_length=30.0, box_width=20.0, box_height=15.0, door_
 
     # Define door cutout (rectangular prism to subtract)
     door_thickness = 0.1  # Thin cutout for subtraction
-    door_vertices = np.array([
-        [box_length - door_thickness, box_width / 2 - door_width / 2, 0],  # Bottom-left
-        [box_length - door_thickness, box_width / 2 + door_width / 2, 0],  # Bottom-right
-        [box_length - door_thickness, box_width / 2 + door_width / 2, door_height],  # Top-right
-        [box_length - door_thickness, box_width / 2 - door_width / 2, door_height],  # Top-left
+    # Create a small box representing the door cutout
+    door = trimesh.creation.box(extents=[door_thickness, door_width, door_height])
+    door.apply_translation([
+        box_length - door_thickness / 2,
+        box_width / 2,
+        door_height / 2,
     ])
-    door_faces = np.array([
-        [0, 1, 2], [0, 2, 3],  # Front face
-        # Add side faces for a thin prism (simplified)
-        [0, 1, 4], [1, 5, 4], [1, 2, 5], [2, 6, 5], [2, 3, 6], [3, 7, 6], [3, 0, 7], [0, 4, 7]
-    ])  # Note: 4-7 vertices would need z-offset, simplified here
-    door = trimesh.Trimesh(vertices=door_vertices, faces=door_faces, process=False)
     door.apply_translation([0, 0, box_height - door_height])  # Position at top of door height
 
     # Subtract door cutout from box


### PR DESCRIPTION
## Summary
- fix `box_with_door` example so the door cutout mesh has proper back vertices
- construct the cutout mesh using `trimesh.creation.box`

## Testing
- `PYTHONPATH=3d_model_maker python - <<'EOF'
import trimesh
from parametric_cad.examples.box_with_door import create_box_with_door
print('Start test')
try:
    door = trimesh.creation.box(extents=[0.1, 10.0, 10.0])
    print('created door is Trimesh:', isinstance(door, trimesh.Trimesh))
except Exception as e:
    print('fail', e)
EOF`

------
https://chatgpt.com/codex/tasks/task_e_687824221d48832993e2b2dacdb531f7