### PR TITLE
Add tests and CI workflow

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,0 +1,20 @@
+name: Python unit tests
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          pip install pytest trimesh shapely
+      - name: Run tests
+        env:
+          PYTHONPATH: ${{ github.workspace }}
+        run: pytest -vv

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,0 +1,13 @@
+import os
+import pytest
+import trimesh
+from parametric_cad.primitives.box import Box
+from parametric_cad.export.stl import STLExporter
+
+
+def test_stl_exporter(tmp_path):
+    exporter = STLExporter(output_dir=tmp_path)
+    box = Box(1.0, 1.0, 1.0)
+    path = exporter.export_mesh(box, "test_box", preview=False)
+    assert os.path.isfile(path)
+    assert path == str(tmp_path / "test_box.stl")

--- a/tests/test_mechanisms.py
+++ b/tests/test_mechanisms.py
@@ -1,0 +1,15 @@
+import numpy as np
+import pytest
+import trimesh
+
+from parametric_cad.mechanisms.butthinge import ButtHinge
+
+
+def test_butthinge_mesh_and_translation():
+    hinge = ButtHinge()
+    mesh = hinge.mesh()
+    assert isinstance(mesh, trimesh.Trimesh)
+    original_centroid = mesh.centroid.copy()
+    hinge.at(1.0, 2.0, 3.0)
+    translated_centroid = hinge.mesh().centroid
+    assert np.allclose(translated_centroid, original_centroid + [1.0, 2.0, 3.0])

--- a/tests/test_primitives.py
+++ b/tests/test_primitives.py
@@ -1,0 +1,23 @@
+import pytest
+import numpy as np
+import trimesh
+from math import cos, pi
+
+from parametric_cad.primitives.box import Box
+from parametric_cad.primitives.gear import SpurGear
+
+
+def test_box_mesh_extents_and_position():
+    box = Box(1.0, 2.0, 3.0).at(1.0, 1.0, 1.0)
+    mesh = box.mesh()
+    assert np.allclose(mesh.centroid, [1.0, 1.0, 1.0])
+    assert mesh.extents[0] == pytest.approx(1.0)
+    assert mesh.extents[1] == pytest.approx(2.0)
+    assert mesh.extents[2] == pytest.approx(3.0)
+
+
+def test_spur_gear_diameters():
+    gear = SpurGear(module=2.0, teeth=10)
+    assert gear.pitch_diameter == pytest.approx(20.0)
+    expected_base = gear.pitch_diameter * cos(20 * pi / 180)
+    assert gear.base_diameter == pytest.approx(expected_base)


### PR DESCRIPTION
## Summary
- add pytest suite covering primitives, mechanisms and exporter
- run unit tests in GitHub Actions using Python 3.x

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687830f84ed883298e6ed36d146687d2