### PR TITLE
Flatten helper scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,15 +12,13 @@ Python scripts for generating 3D printable models using the
 ## Installation
 
 Install the required Python packages and configure OpenSCAD using the
-provided installer script.  From the desired project directory run:
+installer script in the repository root.  From the desired project directory run:
 
 ```bash
 python install_requirements.py
 ```
 
-This installs all Python dependencies and attempts to set up
-`trimesh` for OpenSCAD rendering.  Each top‑level project folder has
-its own copy of this script.
+This installs all Python dependencies and attempts to set up `trimesh` for OpenSCAD rendering.
 
 ## Running the examples
 
@@ -31,6 +29,7 @@ from `parametric_cad/examples/`, for example:
 export PYTHONPATH=.
 python parametric_cad/examples/spur_gear_example.py
 ```
+You can also run all examples at once using `run_examples.py` or the `run_examples.bat` script on Windows.
 
 Generated STL files are written to `output/<example>_output/`.
 

--- a/configure_trimesh_scad.py
+++ b/configure_trimesh_scad.py
@@ -1,0 +1,52 @@
+import os
+import sys
+import trimesh
+import logging
+
+logging.basicConfig(filename='install_debug.log', level=logging.DEBUG, format='%(asctime)s - %(levelname)s - %(message)s')
+
+def configure_trimesh_scad():
+    logging.debug("Starting trimesh configuration process")
+    # Default OpenSCAD path
+    default_path = r"C:\Program Files\OpenSCAD\openscad.exe"
+    openscad_path = os.environ.get("OPENSCAD_PATH", default_path)
+    logging.debug(f"Initial OpenSCAD path set to {openscad_path}")
+
+    print("Configuring trimesh to use OpenSCAD engine...")
+    logging.info("Checking trimesh module availability")
+
+    # Check if trimesh is available
+    try:
+        import trimesh
+        logging.info("trimesh module found")
+        print("trimesh module found.")
+    except ImportError:
+        logging.error("trimesh module not found")
+        print("trimesh module not found! Please ensure it is installed via 'pip install trimesh'.")
+        sys.exit(1)
+
+    # Check if OpenSCAD executable exists
+    logging.debug(f"Verifying OpenSCAD existence at {openscad_path}")
+    if not os.path.exists(openscad_path):
+        logging.warning(f"OpenSCAD not found at {openscad_path}")
+        print(f"OpenSCAD not found at {openscad_path}! Please install OpenSCAD or specify the correct path.")
+        openscad_path = input("Enter the full path to openscad.exe: ")
+        logging.debug(f"User provided OpenSCAD path: {openscad_path}")
+        if not os.path.exists(openscad_path):
+            logging.error("User provided invalid OpenSCAD path")
+            print("Invalid path! Aborting.")
+            sys.exit(1)
+
+    # Note: set_engine_options is not available in trimesh 4.7.0
+    logging.warning("trimesh.boolean.set_engine_options not available in trimesh 4.7.0")
+    print("Warning: trimesh.boolean.set_engine_options is not available in this version of trimesh (4.7.0).")
+    print("To use the OpenSCAD engine, set the OPENSCADPATH environment variable manually or use an older version of trimesh.")
+    print(f"Manually set OPENSCADPATH to {openscad_path} in your environment variables or trimesh configuration.")
+    logging.info(f"Recommended OPENSCADPATH: {openscad_path}")
+
+    print("Restart your Python environment or IDE for changes to take effect.")
+    logging.debug("Configuration process completed, awaiting user input")
+    input("Press Enter to continue...")
+
+if __name__ == "__main__":
+    configure_trimesh_scad()

--- a/install_openscad.py
+++ b/install_openscad.py
@@ -1,0 +1,75 @@
+import os
+import subprocess
+import sys
+import logging
+
+logging.basicConfig(filename='install_debug.log', level=logging.DEBUG, format='%(asctime)s - %(levelname)s - %(message)s')
+
+def download_openscad():
+    try:
+        with open('openscad_download_url.txt', 'r') as f:
+            url = f.read().strip()
+    except FileNotFoundError:
+        logging.error("openscad_download_url.txt not found! Please run scrape_openscad_download.py first.")
+        print("openscad_download_url.txt not found! Please run scrape_openscad_download.py first to get the latest URL.")
+        sys.exit(1)
+    
+    installer = os.path.basename(url)
+    logging.debug(f"Attempting to download OpenSCAD from {url}")
+    print("Downloading OpenSCAD installer...")
+    try:
+        response = requests.get(url, stream=True)
+        response.raise_for_status()
+        logging.info(f"Download started for {url}")
+        with open(installer, 'wb') as f:
+            for chunk in response.iter_content(chunk_size=8192):
+                f.write(chunk)
+        logging.info(f"Download completed, saved as {installer}")
+        print("Download completed.")
+        return True
+    except requests.RequestException as e:
+        logging.error(f"Download failed: {e}")
+        print(f"Failed to download OpenSCAD installer: {e}")
+        return False
+
+def install_openscad():
+    installer = os.path.basename(url)  # Use the same name as downloaded
+    logging.debug(f"Checking if installer exists at {installer}")
+    if not os.path.exists(installer):
+        logging.warning("Installer not found after download attempt")
+        print("Installer not found! Download failed.")
+        return False
+    
+    logging.info(f"Starting installation of {installer}")
+    print("Installing OpenSCAD...")
+    try:
+        subprocess.run([installer, "/S"], check=True, shell=True)
+        logging.info("OpenSCAD installation completed")
+        print("OpenSCAD installed successfully.")
+        return True
+    except subprocess.CalledProcessError as e:
+        logging.error(f"Installation failed: {e}")
+        print(f"Installation failed: {e}")
+        return False
+
+def cleanup():
+    installer = os.path.basename(url)
+    logging.debug(f"Checking for cleanup of {installer}")
+    if os.path.exists(installer):
+        os.remove(installer)
+        logging.info(f"Cleaned up installer file {installer}")
+        print("Cleaned up installer file.")
+
+if __name__ == "__main__":
+    import requests  # Import here to avoid circular dependency issues
+    logging.debug("Starting install_openscad.py execution")
+    if not download_openscad():
+        sys.exit(1)
+    if not install_openscad():
+        cleanup()
+        sys.exit(1)
+    cleanup()
+    logging.info("OpenSCAD installation process completed")
+    print("Please ensure OpenSCAD is added to your system PATH.")
+    print("You may need to restart your command prompt or system for changes to take effect.")
+    input("Press Enter to continue...")

--- a/install_requirements.py
+++ b/install_requirements.py
@@ -1,0 +1,53 @@
+import subprocess
+import sys
+import logging
+
+logging.basicConfig(filename='install_debug.log', level=logging.DEBUG, format='%(asctime)s - %(levelname)s - %(message)s')
+
+def install_openscad():
+    logging.debug("Starting OpenSCAD installation process")
+    print("Installing OpenSCAD dependency...")
+    try:
+        subprocess.run([sys.executable, "install_openscad.py"], check=True)
+        logging.info("OpenSCAD installation completed successfully")
+        print("OpenSCAD installation completed.")
+    except subprocess.CalledProcessError:
+        logging.error("OpenSCAD installation failed")
+        print("Failed to install OpenSCAD. Continuing with Python packages...")
+        return False
+    return True
+
+def install_python_packages():
+    logging.debug("Starting Python package installation process")
+    print("Installing all required Python packages including triangulation engines...")
+    packages = ["trimesh", "numpy", "matplotlib", "pyglet<2", "networkx", "scipy", "shapely", 
+                "triangle", "mapbox_earcut", "manifold3d", "pillow", "requests", "beautifulsoup4"]
+    try:
+        subprocess.run([sys.executable, "-m", "pip", "install"] + packages, check=True)
+        logging.info("Python packages installed successfully")
+        print("Python packages installed successfully.")
+    except subprocess.CalledProcessError:
+        logging.error("Python package installation failed")
+        print("Failed to install Python packages!")
+        sys.exit(1)
+
+def configure_trimesh_scad():
+    logging.debug("Starting trimesh configuration process")
+    print("Configuring trimesh for OpenSCAD...")
+    try:
+        subprocess.run([sys.executable, "configure_trimesh_scad.py"], check=True)
+        logging.info("trimesh configuration completed")
+    except subprocess.CalledProcessError:
+        logging.error("trimesh configuration failed")
+        print("Failed to configure trimesh for OpenSCAD. You may need to run configure_trimesh_scad.py manually.")
+        return False
+    return True
+
+if __name__ == "__main__":
+    logging.debug("Starting install_requirements.py execution")
+    install_openscad()
+    install_python_packages()
+    configure_trimesh_scad()
+    logging.info("All installation processes completed")
+    print("\n✅ All dependencies and OpenSCAD configured (manual trimesh configuration may be required).")
+    input("Press Enter to continue...")

--- a/run_examples.bat
+++ b/run_examples.bat
@@ -1,0 +1,38 @@
+@echo off
+cd /d %~dp0
+set PYTHONPATH=.
+
+echo Running box_with_door.py...
+python parametric_cad\examples\box_with_door.py
+
+echo Running hollow_box.py...
+python parametric_cad\examples\hollow_box.py
+
+echo Running spur_gear_example.py...
+python parametric_cad\examples\spur_gear_example.py
+
+echo.
+echo Checking box_with_door_output folder...
+if exist output\box_with_door_output (
+    dir output\box_with_door_output
+) else (
+    echo ERROR: box_with_door_output folder does not exist!
+)
+
+echo.
+echo Checking hollow_box_output folder...
+if exist output\hollow_box_output (
+    dir output\hollow_box_output
+) else (
+    echo ERROR: hollow_box_output folder does not exist!
+)
+
+echo.
+echo Checking spur_gear_example_output folder...
+if exist output\spur_gear_example_output (
+    dir output\spur_gear_example_output
+) else (
+    echo ERROR: spur_gear_example_output folder does not exist!
+)
+
+pause

--- a/scrape_openscad_download.py
+++ b/scrape_openscad_download.py
@@ -1,0 +1,54 @@
+import requests
+import re
+from bs4 import BeautifulSoup
+import logging
+
+logging.basicConfig(filename='scrape_debug.log', level=logging.DEBUG, format='%(asctime)s - %(levelname)s - %(message)s')
+
+def scrape_openscad_download():
+    url = "https://www.openscad.org/downloads.html"
+    logging.debug(f"Attempting to scrape {url}")
+    print(f"Scraping {url} for the latest OpenSCAD Windows 64-bit installer...")
+    
+    try:
+        response = requests.get(url, timeout=10)
+        response.raise_for_status()
+        logging.info(f"Successfully fetched {url}")
+        soup = BeautifulSoup(response.text, 'html.parser')
+        
+        # Look for links containing ".exe" and "Win64" in the text
+        latest_link = None
+        for link in soup.find_all('a', href=True):
+            href = link.get('href')
+            if href and '.exe' in href.lower() and 'win64' in href.lower():
+                latest_link = href
+                logging.info(f"Found potential download link: {latest_link}")
+                break
+        
+        if not latest_link:
+            logging.error("No Windows 64-bit .exe link found on the page")
+            print("No Windows 64-bit .exe link found! Please check the website manually.")
+            return None
+        
+        # Ensure the link is absolute
+        if not latest_link.startswith('http'):
+            latest_link = f"https://www.openscad.org{latest_link}"
+        
+        logging.info(f"Latest Windows 64-bit installer URL: {latest_link}")
+        print(f"Latest Windows 64-bit installer found: {latest_link}")
+        return latest_link
+    
+    except requests.RequestException as e:
+        logging.error(f"Failed to scrape {url}: {e}")
+        print(f"Failed to scrape {url}: {e}")
+        return None
+
+if __name__ == "__main__":
+    logging.debug("Starting scrape_openscad_download.py execution")
+    download_url = scrape_openscad_download()
+    if download_url:
+        with open('openscad_download_url.txt', 'w') as f:
+            f.write(download_url)
+        logging.info(f"Saved download URL to openscad_download_url.txt")
+        print(f"Download URL saved to openscad_download_url.txt")
+    input("Press Enter to continue...")


### PR DESCRIPTION
## Summary
- add install scripts and configuration script at repo root
- provide Windows batch helper for running examples
- update README with updated script locations

## Testing
- `pip install trimesh numpy matplotlib 'pyglet<2' networkx scipy shapely triangle mapbox_earcut manifold3d pillow requests beautifulsoup4 -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687833926eb88329896e9f7f2d0880a4