### PR TITLE
Switch exports to ASCII STL

### DIFF
--- a/parametric_cad/export/stl.py
+++ b/parametric_cad/export/stl.py
@@ -12,7 +12,7 @@ logging.basicConfig(filename='stl_export.log', level=logging.INFO,
 class STLExporter:
     """Export trimesh objects to STL with optional previews."""
 
-    def __init__(self, output_dir="output", binary=True):
+    def __init__(self, output_dir="output", binary=False):
         self.output_dir = output_dir
         self.binary = binary
         os.makedirs(self.output_dir, exist_ok=True)

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,5 +1,4 @@
 import os
-import pytest
 import trimesh
 from parametric_cad.primitives.box import Box
 from parametric_cad.primitives.cylinder import Cylinder
@@ -13,10 +12,21 @@ def test_stl_exporter(tmp_path):
     path = exporter.export_mesh(box, "test_box", preview=False)
     assert os.path.isfile(path)
     assert path == str(tmp_path / "test_box.stl")
+    with open(path, "r", encoding="utf-8") as f:
+        contents = f.read()
+    mesh = trimesh.util.concatenate([box.mesh()])
+    if not mesh.is_watertight or mesh.vertices.shape[0] == 0:
+        repaired = mesh.fill_holes()
+        if repaired is not False:
+            mesh = repaired
+        else:
+            mesh = mesh.convex_hull
+    expected = trimesh.exchange.stl.export_stl_ascii(mesh)
+    assert contents == expected
 
 
 def test_ascii_stl_multiple_objects(tmp_path):
-    exporter = STLExporter(output_dir=tmp_path, binary=False)
+    exporter = STLExporter(output_dir=tmp_path)
     box = Box(1.0, 2.0, 1.0)
     cyl = Cylinder(radius=0.5, height=1.0)
     sph = Sphere(radius=0.25)
@@ -24,5 +34,13 @@ def test_ascii_stl_multiple_objects(tmp_path):
     assert os.path.isfile(path)
     assert path == str(tmp_path / "combo.stl")
     with open(path, "r", encoding="utf-8") as f:
-        first_line = f.readline().strip()
-    assert first_line.startswith("solid")
+        contents = f.read()
+    mesh = trimesh.util.concatenate([box.mesh(), cyl.mesh(), sph.mesh()])
+    if not mesh.is_watertight or mesh.vertices.shape[0] == 0:
+        repaired = mesh.fill_holes()
+        if repaired is not False:
+            mesh = repaired
+        else:
+            mesh = mesh.convex_hull
+    expected = trimesh.exchange.stl.export_stl_ascii(mesh)
+    assert contents == expected


### PR DESCRIPTION
## Summary
- default `STLExporter` to ASCII output
- verify the exact contents of generated STL files

## Testing
- `pip install pytest trimesh shapely`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68783c03b0588329b86111260bcf6253