### PR TITLE
Add geometry wrapper for shapely

### DIFF
--- a/parametric_cad/__init__.py
+++ b/parametric_cad/__init__.py
@@ -1,6 +1,7 @@
 """Consolidated parametric_cad package."""
 
 from .core import tm, safe_difference, combine
+from .geometry import sg, Polygon, Point, box
 from .primitives.box import Box
 from .primitives.cylinder import Cylinder
 from .primitives.gear import SpurGear
@@ -10,6 +11,7 @@ from .export.stl import STLExporter
 
 __all__ = [
     "tm",
+    "sg",
     "safe_difference",
     "combine",
     "Box",
@@ -18,4 +20,7 @@ __all__ = [
     "ChainSprocket",
     "ButtHinge",
     "STLExporter",
+    "Polygon",
+    "Point",
+    "box",
 ]

--- a/parametric_cad/examples/declarative_rc_car_chassis.py
+++ b/parametric_cad/examples/declarative_rc_car_chassis.py
@@ -3,7 +3,7 @@
 
 from math import pi
 
-from shapely.geometry import box, Point
+from parametric_cad.geometry import box, Point
 
 from parametric_cad.primitives.box import Box
 from parametric_cad.primitives.cylinder import Cylinder

--- a/parametric_cad/geometry.py
+++ b/parametric_cad/geometry.py
@@ -1,0 +1,19 @@
+"""Wrapper around shapely.geometry used by parametric_cad.
+
+This indirection allows the project to avoid depending on shapely
+throughout the codebase. If needed, the backend can be swapped out
+by modifying this module alone.
+"""
+
+import shapely.geometry as _geometry
+
+# Public alias so other modules can import geometry functionality
+# without referencing :mod:`shapely` directly.
+sg = _geometry
+
+# Commonly used geometry primitives
+Polygon = sg.Polygon
+Point = sg.Point
+box = sg.box
+
+__all__ = ["sg", "Polygon", "Point", "box"]

--- a/parametric_cad/primitives/gear.py
+++ b/parametric_cad/primitives/gear.py
@@ -1,6 +1,6 @@
 import numpy as np
 from parametric_cad.core import tm, safe_difference
-from shapely.geometry import Polygon
+from parametric_cad.geometry import Polygon
 from math import pi, sin, cos, tan
 import logging
 


### PR DESCRIPTION
## Summary
- add `geometry.py` that exposes shapely via our API
- stop importing shapely directly in primitives and examples
- export geometry helpers in package `__init__`

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878b63803088329a77a9a7484d8544f