### PR TITLE
Update example scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ from `parametric_cad/examples/`, for example:
 export PYTHONPATH=.
 python parametric_cad/examples/spur_gear_example.py
 ```
-You can also run all examples at once using `run_examples.py` or the `run_examples.bat` script on Windows.
+You can also run all examples at once using the cross-platform `run_examples.py` script.
 
 Generated STL files are written to `output/<example>_output/`.
 

--- a/run_examples.bat
+++ b/run_examples.bat
@@ -1,38 +1,8 @@
 @echo off
+REM Run all Python examples using the cross-platform script
 cd /d %~dp0
 set PYTHONPATH=.
 
-echo Running box_with_door.py...
-python parametric_cad\examples\box_with_door.py
-
-echo Running hollow_box.py...
-python parametric_cad\examples\hollow_box.py
-
-echo Running spur_gear_example.py...
-python parametric_cad\examples\spur_gear_example.py
-
-echo.
-echo Checking box_with_door_output folder...
-if exist output\box_with_door_output (
-    dir output\box_with_door_output
-) else (
-    echo ERROR: box_with_door_output folder does not exist!
-)
-
-echo.
-echo Checking hollow_box_output folder...
-if exist output\hollow_box_output (
-    dir output\hollow_box_output
-) else (
-    echo ERROR: hollow_box_output folder does not exist!
-)
-
-echo.
-echo Checking spur_gear_example_output folder...
-if exist output\spur_gear_example_output (
-    dir output\spur_gear_example_output
-) else (
-    echo ERROR: spur_gear_example_output folder does not exist!
-)
+python run_examples.py
 
 pause


### PR DESCRIPTION
## Summary
- reduce duplication by turning run_examples.bat into a simple wrapper
- reference the cross-platform script in README

## Testing
- `pip install -q -r <(printf "pytest\ntrimesh\nnumpy\nmatplotlib\npyglet<2\nnetworkx\nscipy\nshapely\ntriangle\nmapbox_earcut\nmanifold3d\npillow\nrequests\nbeautifulsoup4")`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878c1e67bc48329bf8f05074ccfc398