### PR TITLE
Centralize logging setup

### DIFF
--- a/parametric_cad/examples/box_with_door.py
+++ b/parametric_cad/examples/box_with_door.py
@@ -1,6 +1,9 @@
 from parametric_cad.primitives.box import Box
 from parametric_cad.mechanisms.butthinge import ButtHinge
 from parametric_cad.export.stl import STLExporter
+from parametric_cad.logging_config import setup_logging
+
+setup_logging()
 
 box = Box(100, 60, 40).at(0, 0, 0)
 door = Box(100, 3, 40).at(0, 63, 0)

--- a/parametric_cad/examples/declarative_motor_bracket.py
+++ b/parametric_cad/examples/declarative_motor_bracket.py
@@ -4,6 +4,9 @@ from parametric_cad.primitives.box import Box
 from parametric_cad.primitives.cylinder import Cylinder
 from parametric_cad.core import combine, safe_difference
 from parametric_cad.export.stl import STLExporter
+from parametric_cad.logging_config import setup_logging
+
+setup_logging()
 
 # Basic dimensions for a 540/550 motor bracket
 BASE_LENGTH = 50.0

--- a/parametric_cad/examples/declarative_rc_car_chassis.py
+++ b/parametric_cad/examples/declarative_rc_car_chassis.py
@@ -9,6 +9,9 @@ from parametric_cad.primitives.box import Box
 from parametric_cad.primitives.cylinder import Cylinder
 from parametric_cad.core import combine, safe_difference, tm
 from parametric_cad.export.stl import STLExporter
+from parametric_cad.logging_config import setup_logging
+
+setup_logging()
 
 # Basic chassis dimensions (all units in mm)
 BASE_LENGTH = 200.0

--- a/parametric_cad/examples/hollow_box.py
+++ b/parametric_cad/examples/hollow_box.py
@@ -1,6 +1,9 @@
 from parametric_cad.primitives.box import Box
 from parametric_cad.export.stl import STLExporter
 from parametric_cad.core import safe_difference
+from parametric_cad.logging_config import setup_logging
+
+setup_logging()
 
 outer = Box(100, 60, 40).at(0, 0, 0)
 inner = Box(90, 50, 30).at(5, 5, 5)

--- a/parametric_cad/examples/motor_bracket_example.py
+++ b/parametric_cad/examples/motor_bracket_example.py
@@ -1,5 +1,8 @@
 from parametric_cad.mechanisms.motor_bracket import RightAngleMotorBracket
 from parametric_cad.export.stl import STLExporter
+from parametric_cad.logging_config import setup_logging
+
+setup_logging()
 
 bracket = RightAngleMotorBracket()
 

--- a/parametric_cad/examples/sprocket_example.py
+++ b/parametric_cad/examples/sprocket_example.py
@@ -1,5 +1,8 @@
 from parametric_cad.primitives.sprocket import ChainSprocket
 from parametric_cad.export.stl import STLExporter
+from parametric_cad.logging_config import setup_logging
+
+setup_logging()
 
 # Example sprocket for #420 chain (pitch 12.7 mm, roller dia ~7.75 mm)
 

--- a/parametric_cad/examples/spur_gear_example.py
+++ b/parametric_cad/examples/spur_gear_example.py
@@ -1,5 +1,8 @@
 from parametric_cad.primitives.gear import SpurGear
 from parametric_cad.export.stl import STLExporter
+from parametric_cad.logging_config import setup_logging
+
+setup_logging()
 
 gear = SpurGear(module=1.0, teeth=20, width=8.0, bore_diameter=5.0, hole_count=6, hole_diameter=2.5)
 exporter = STLExporter(output_dir="output/spur_gear_example_output")

--- a/parametric_cad/export/stl.py
+++ b/parametric_cad/export/stl.py
@@ -5,9 +5,6 @@ import numpy as np
 from pathlib import Path
 from datetime import datetime
 
-logging.basicConfig(filename='stl_export.log', level=logging.INFO,
-                    format='%(asctime)s - %(levelname)s - %(message)s')
-
 class STLExporter:
     """Export trimesh objects to STL with optional previews."""
 

--- a/parametric_cad/logging_config.py
+++ b/parametric_cad/logging_config.py
@@ -1,0 +1,12 @@
+import logging
+from typing import Optional
+
+
+def setup_logging(
+    filename: Optional[str] = None,
+    level: int = logging.INFO,
+    format: str = "%(asctime)s - %(levelname)s - %(message)s",
+) -> None:
+    """Configure basic logging for examples and utilities."""
+    logging.basicConfig(filename=filename, level=level, format=format)
+

--- a/parametric_cad/primitives/gear.py
+++ b/parametric_cad/primitives/gear.py
@@ -8,14 +8,6 @@ from parametric_cad.core import safe_difference, tm
 from parametric_cad.geometry import Polygon
 from .base import Primitive
 
-# Set up logging to file
-logging.basicConfig(
-    filename="gear_debug.log",
-    level=logging.DEBUG,
-    format="%(asctime)s - %(levelname)s - %(message)s",
-)
-
-
 class SpurGear(Primitive):
     def __init__(
         self,


### PR DESCRIPTION
## Summary
- create `setup_logging` helper
- remove logging configuration from modules
- call `setup_logging` in examples

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879211de08883299877b5ca8b2ac668