### PR TITLE
Convert primitives to dataclasses

### DIFF
--- a/parametric_cad/primitives/box.py
+++ b/parametric_cad/primitives/box.py
@@ -1,13 +1,19 @@
+from dataclasses import dataclass
+
 from parametric_cad.core import tm
 from .base import Primitive
 
 
+@dataclass
 class Box(Primitive):
-    def __init__(self, width: float, depth: float, height: float) -> None:
+    """Axis-aligned rectangular prism primitive."""
+
+    width: float
+    depth: float
+    height: float
+
+    def __post_init__(self) -> None:
         super().__init__()
-        self.width = width
-        self.depth = depth
-        self.height = height
 
     def _create_mesh(self) -> tm.Trimesh:
         return tm.creation.box(extents=(self.width, self.depth, self.height))

--- a/parametric_cad/primitives/cylinder.py
+++ b/parametric_cad/primitives/cylinder.py
@@ -1,15 +1,19 @@
-from typing import Sequence
+from dataclasses import dataclass
 
 from parametric_cad.core import tm
 from .base import Primitive
 
 
+@dataclass
 class Cylinder(Primitive):
-    def __init__(self, radius: float, height: float, sections: int = 32) -> None:
+    """Circular cylinder primitive."""
+
+    radius: float
+    height: float
+    sections: int = 32
+
+    def __post_init__(self) -> None:
         super().__init__()
-        self.radius = radius
-        self.height = height
-        self.sections = sections
 
     def _create_mesh(self) -> tm.Trimesh:
         return tm.creation.cylinder(

--- a/parametric_cad/primitives/sphere.py
+++ b/parametric_cad/primitives/sphere.py
@@ -1,12 +1,18 @@
+from dataclasses import dataclass
+
 from parametric_cad.core import tm
 from .base import Primitive
 
 
+@dataclass
 class Sphere(Primitive):
-    def __init__(self, radius: float, subdivisions: int = 3) -> None:
+    """Icosphere primitive."""
+
+    radius: float
+    subdivisions: int = 3
+
+    def __post_init__(self) -> None:
         super().__init__()
-        self.radius = radius
-        self.subdivisions = subdivisions
 
     def _create_mesh(self) -> tm.Trimesh:
         return tm.creation.icosphere(


### PR DESCRIPTION
## Summary
- refactor `Box`, `Cylinder`, and `Sphere` primitives to use `@dataclass`
- keep public behaviour while providing typed fields and post-init

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687930d3eb2c8329b8d32566aa2e5015