### PR TITLE
Add return type hints to Primitive methods

### DIFF
--- a/parametric_cad/primitives/base.py
+++ b/parametric_cad/primitives/base.py
@@ -1,4 +1,4 @@
-from typing import Optional, Sequence
+from typing import Optional, Sequence, Self
 
 from parametric_cad.core import tm
 
@@ -10,12 +10,12 @@ class Primitive:
         self._position = (0.0, 0.0, 0.0)
         self._rotation: Optional[tuple[Sequence[float], float]] = None
 
-    def at(self, x: float, y: float, z: float):
+    def at(self, x: float, y: float, z: float) -> Self:
         """Translate the primitive to ``(x, y, z)``."""
         self._position = (x, y, z)
         return self
 
-    def rotate(self, axis: Sequence[float], angle: float):
+    def rotate(self, axis: Sequence[float], angle: float) -> Self:
         """Rotate the primitive around ``axis`` by ``angle`` radians."""
         self._rotation = (axis, angle)
         return self


### PR DESCRIPTION
## Summary
- add explicit return annotations for `Primitive.at` and `Primitive.rotate`

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879f77c6c6c83298161f3145a7960c4