### PR TITLE
Add Bambu printability rules and validator

### DIFF
--- a/bambu_printability_rules.json
+++ b/bambu_printability_rules.json
@@ -1,0 +1,38 @@
+{
+  "printer": "Bambu Labs",
+  "nozzle_diameter_mm": 0.4,
+  "layer_height_mm": 0.2,
+  "rules": {
+    "minimum_wall_thickness_mm": 0.8,
+    "minimum_embossed_detail_height_mm": 0.2,
+    "minimum_engraved_detail_depth_mm": 0.2,
+    "minimum_text_height_mm": 4.0,
+    "minimum_text_line_thickness_mm": 0.5,
+    "minimum_hole_diameter_mm": 2.0,
+    "hole_size_tolerance_mm": 0.2,
+    "bridge_max_length_mm": 5.0,
+    "overhang_max_angle_deg": 45,
+    "minimum_clearance_between_parts_mm": 0.3,
+    "minimum_feature_size_mm": 0.4,
+    "recommended_support_gap_mm": 0.2,
+    "minimum_chamfer_or_fillet_mm": 0.5,
+    "max_model_size_mm": {
+      "X": 256,
+      "Y": 256,
+      "Z": 256
+    },
+    "maximum_file_triangle_count": 1000000,
+    "manifold_geometry_required": true,
+    "no_intersecting_geometry": true,
+    "no_open_edges": true,
+    "preferred_file_format": "STL",
+    "alternate_file_formats": ["3MF", "OBJ"]
+  },
+  "notes": [
+    "Values are tuned for typical Bambu Lab P1P, P1S, X1, or A1 with 0.4 mm nozzle.",
+    "Minimum feature sizes are physical—anything smaller may not print or adhere properly.",
+    "Bridge length and overhang angle assume no support and average cooling.",
+    "Clearance depends on material shrinkage—tune for specific filament types.",
+    "For press-fit or moving parts, increase clearance to 0.4–0.5 mm."
+  ]
+}

--- a/parametric_cad/__init__.py
+++ b/parametric_cad/__init__.py
@@ -10,6 +10,7 @@ from .primitives.sprocket import ChainSprocket
 from .primitives.sphere import Sphere
 from .mechanisms.butthinge import ButtHinge
 from .export.stl import STLExporter
+from .printability import PrintabilityValidator
 
 __all__ = [
     "tm",
@@ -24,6 +25,7 @@ __all__ = [
     "ChainSprocket",
     "ButtHinge",
     "STLExporter",
+    "PrintabilityValidator",
     "Polygon",
     "Point",
     "box",

--- a/parametric_cad/printability.py
+++ b/parametric_cad/printability.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import List
+
+from .core import tm
+import numpy as np
+
+
+def _default_rules_path() -> Path:
+    return Path(__file__).resolve().parent.parent / "bambu_printability_rules.json"
+
+
+class PrintabilityValidator:
+    """Validate meshes against Bambu Labs printability guidelines."""
+
+    def __init__(self, rules_file: str | Path | None = None) -> None:
+        path = Path(rules_file) if rules_file else _default_rules_path()
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        self.rules = data.get("rules", {})
+        self.rules_file = path
+
+    def validate_mesh(self, mesh: tm.Trimesh) -> List[str]:
+        r = self.rules
+        errors: List[str] = []
+
+        if r.get("manifold_geometry_required") and not mesh.is_watertight:
+            errors.append("Mesh is not watertight")
+
+        if r.get("no_open_edges") and mesh.euler_number < 2:
+            errors.append("Mesh has open edges")
+
+        if r.get("no_intersecting_geometry"):
+            try:
+                if mesh.is_self_intersecting:
+                    errors.append("Mesh has self intersections")
+            except Exception:
+                pass
+
+        max_tris = r.get("maximum_file_triangle_count")
+        if max_tris and mesh.faces.shape[0] > max_tris:
+            errors.append(
+                f"Triangle count {mesh.faces.shape[0]} exceeds maximum of {max_tris}"
+            )
+
+        max_size = r.get("max_model_size_mm", {})
+        extents = mesh.extents
+        for axis, idx in zip(["X", "Y", "Z"], range(3)):
+            max_dim = max_size.get(axis)
+            if max_dim and extents[idx] > max_dim:
+                errors.append(
+                    f"{axis} dimension {extents[idx]:.2f}mm exceeds max of {max_dim}mm"
+                )
+
+        min_feat = r.get("minimum_feature_size_mm")
+        if min_feat:
+            try:
+                min_len = float(min(mesh.edges_unique_length))
+                if min_len < min_feat:
+                    errors.append(
+                        f"Minimum feature size {min_len:.2f}mm below {min_feat}mm"
+                    )
+            except Exception:
+                pass
+
+        max_angle = r.get("overhang_max_angle_deg")
+        if max_angle is not None:
+            normals = mesh.face_normals
+            min_z = mesh.bounds[0, 2]
+            downward = (normals[:, 2] < 0) & (
+                mesh.triangles_center[:, 2] > min_z + 1e-6
+            )
+            if np.any(downward):
+                angles = np.degrees(
+                    np.arccos(np.clip(normals[downward, 2], -1.0, 1.0))
+                )
+                if angles.size > 0 and angles.max() > max_angle:
+                    errors.append("Overhang angle exceeds maximum")
+
+        return errors
+
+    def validate_file(self, file_path: str | Path) -> List[str]:
+        mesh = tm.load(file_path)
+        return self.validate_mesh(mesh)
+
+
+__all__ = ["PrintabilityValidator"]

--- a/tests/test_printability.py
+++ b/tests/test_printability.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+from parametric_cad.primitives.box import Box
+from parametric_cad.printability import PrintabilityValidator
+
+RULES_PATH = Path(__file__).resolve().parents[1] / "bambu_printability_rules.json"
+
+
+def test_box_compliance():
+    box = Box(10.0, 10.0, 10.0)
+    validator = PrintabilityValidator(RULES_PATH)
+    errors = validator.validate_mesh(box.mesh())
+    assert errors == []
+
+
+def test_dimension_violation():
+    big_box = Box(300.0, 10.0, 10.0)
+    validator = PrintabilityValidator(RULES_PATH)
+    errors = validator.validate_mesh(big_box.mesh())
+    assert any("X dimension" in e for e in errors)


### PR DESCRIPTION
## Summary
- add `bambu_printability_rules.json`
- implement `PrintabilityValidator` to check models against Bambu rules
- export new validator in the package namespace
- test validation logic with small and oversized boxes

## Testing
- `pip install --quiet trimesh numpy shapely pytest`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a0a827728832992bc2e8bcb09bfb0